### PR TITLE
Fix#7

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt README.md requirements.txt

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ the internet into geospatial raster files. Bounding boxes can be passed in both 
 * `mercantile`
 * `numpy`
 * `pandas`
-* `PIL`
+* `pillow`
 * `rasterio`
 * `six`
 * `urllib2`

--- a/README_dev.md
+++ b/README_dev.md
@@ -15,5 +15,9 @@ This assumes you also have installed `pytest-cov`.
 Cutting a release and updating to `pypi` requires the following steps:
 
 * Make sure tests pass locally and on CI.
-* 
+* Update the version on `setup.py`
+* Run `python setup.py sdist`.
+* When connected to the internet, run `python setup.py register` to login on
+  PyPi.
+* When ready to push up, run `python setup.py sdist upload`.
 

--- a/README_dev.md
+++ b/README_dev.md
@@ -1,0 +1,19 @@
+# Development notes
+
+## Testing
+
+Testing relies on `pytest` and  `pytest-cov`. To run the test suite locally:
+
+```
+python -m pytest -v tests/ --cov contextily
+```
+
+This assumes you also have installed `pytest-cov`.
+
+## Releasing
+
+Cutting a release and updating to `pypi` requires the following steps:
+
+* Make sure tests pass locally and on CI.
+* 
+

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,4 @@ setup(name='contextily',
       license='3-Clause BSD',
       packages=['contextily'],
       install_requires=install_requires,
-      package_data={'cenpy': ['stfipstable.csv']},
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,13 @@ with open('requirements.txt') as f:
 install_requires = [t.strip() for t in tests_require]
 
 setup(name='contextily',
-      version='0.9.1',
+      version='0.9.2',
       description='Context geo-tiles in Python',
       url='https://github.com/darribas/contextily',
       author='Dani Arribas-Bel',
       author_email='daniel.arribas.bel@gmail.com',
       license='3-Clause BSD',
       packages=['contextily'],
+      package_data={'': ['requirements.txt']},
       install_requires=install_requires,
       zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('requirements.txt') as f:
 install_requires = [t.strip() for t in tests_require]
 
 setup(name='contextily',
-      version='0.9.0',
+      version='0.9.1',
       description='Context geo-tiles in Python',
       url='https://github.com/darribas/contextily',
       author='Dani Arribas-Bel',


### PR DESCRIPTION
This includes `pillow` instead of `PIL` as a requirement, which allows to run it on Python 3.X, thus fixing Issue #7 .