### PR TITLE
Fix for #12 by turning  intro  when specifying dtype of output raster in

### DIFF
--- a/contextily/__init__.py
+++ b/contextily/__init__.py
@@ -75,7 +75,7 @@ def bounds2raster(w, s, e, n, zoom, path,
     #---
     raster = rio.open(path, 'w',
                       driver='GTiff', height=h, width=w,
-                      count=b, dtype=Z.dtype,
+                      count=b, dtype=str(Z.dtype),
                       crs='epsg:3857', transform=transform)
     for band in range(b):
         raster.write(Z[:, :, band], band+1)


### PR DESCRIPTION
Fix for #12 by passing `str(dtype)` instead of `dtype` from `Z` to the raster writer.