### PR TITLE
add_basemap: keep original axis limits of figure

### DIFF
--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -73,11 +73,11 @@ def add_basemap(ax, zoom=ZOOM, url=sources.ST_TERRAIN,
     >>> plt.show()
 
     """
+    xmin, xmax, ymin, ymax = ax.axis()
     # If web source
     if url[:4] == 'http':
         # Extent
-        left, right = ax.get_xlim()
-        bottom, top = ax.get_ylim()
+        left, right, bottom, top = xmin, xmax, ymin, ymax
         # Zoom
         if isinstance(zoom, str) and (zoom.lower() == 'auto'):
             min_ll = _sm2ll(left, bottom)
@@ -97,8 +97,11 @@ def add_basemap(ax, zoom=ZOOM, url=sources.ST_TERRAIN,
     # Plotting
     ax.imshow(image, extent=extent, 
               interpolation=interpolation, **extra_imshow_args)
+    ax.axis((xmin, xmax, ymin, ymax))
+
     if attribution:
         add_attribution(ax, attribution, font_size=attribution_size)
+
     return ax
 
 def add_attribution(ax, att=ATTRIBUTION, font_size=ATTRIBUTION_SIZE):

--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -13,8 +13,8 @@ ATTRIBUTION_SIZE = 8
 
 def add_basemap(ax, zoom=ZOOM, url=sources.ST_TERRAIN, 
 		interpolation=INTERPOLATION, attribution = ATTRIBUTION, 
-        attribution_size = ATTRIBUTION_SIZE,
-                **extra_imshow_args):
+        attribution_size = ATTRIBUTION_SIZE, reset_extent=True,
+        **extra_imshow_args):
     """
     Add a (web/local) basemap to `ax`
     ...
@@ -43,6 +43,10 @@ def add_basemap(ax, zoom=ZOOM, url=sources.ST_TERRAIN,
     attribution_size    : int
                           [Optional. Defaults to `ATTRIBUTION_SIZE`].
                           Font size to render attribution text with.
+    reset_extent        : Boolean
+                          [Optional. Default=True] If True, the extent of the
+                          basemap added is reset to the original extent (xlim,
+                          ylim) of `ax`
     **extra_imshow_args : dict
                           Other parameters to be passed to `imshow`.
 
@@ -97,7 +101,9 @@ def add_basemap(ax, zoom=ZOOM, url=sources.ST_TERRAIN,
     # Plotting
     ax.imshow(image, extent=extent, 
               interpolation=interpolation, **extra_imshow_args)
-    ax.axis((xmin, xmax, ymin, ymax))
+
+    if reset_extent:
+        ax.axis((xmin, xmax, ymin, ymax))
 
     if attribution:
         add_attribution(ax, attribution, font_size=attribution_size)

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -149,14 +149,15 @@ def test_add_basemap():
                        4852834.0517692715, 4891969.810251278]
 
     # Test web basemap
-    f, ax = matplotlib.pyplot.subplots(1)
+    fig, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
     ax = ctx.add_basemap(ax, zoom=10)
 
-    ax_extent = (-11740727.544603072, -11662456.027639052,
-                  4852834.0517692715, 4891969.810251278)
-    assert_array_almost_equal(ax_extent, ax.images[0].get_extent())
+    # ensure add_basemap did not change the axis limits of ax
+    ax_extent = (x1, x2, y1, y2)
+    assert ax.axis() == ax_extent
+
     assert ax.images[0].get_array().sum() == 75853866
     assert ax.images[0].get_array().shape == (256, 512, 3)
     assert_array_almost_equal(ax.images[0].get_array().mean(),


### PR DESCRIPTION
Opening this for discussion: in my original implementation (http://geopandas.readthedocs.io/en/latest/gallery/plotting_basemap_background.html#contextily-helper-function) I reset the axis limits to the original ones when the `ax` is passed to the function. 

One reason to do this: the extent of the figure does not depend on the zoom level (on how many tiles are merged).

Closes https://github.com/darribas/contextily/issues/45
