### PR TITLE
Add __version__ attribute

### DIFF
--- a/contextily/__init__.py
+++ b/contextily/__init__.py
@@ -6,3 +6,5 @@ from . import tile_providers as sources
 from .place import Place, plot_map
 from .tile import *
 from .plotting import add_basemap
+
+__version__ = '0.99.0.dev'


### PR DESCRIPTION
This PR adds a `contextily.__version__` attribute, to have a minimal change to have a version.

Going forward, we may want to discuss this further:

- with the current version of this PR, when releasing that would mean updating the version tag in both `__init__.py` and `setup.py`

Alternatively, we can also do it in some other ways: https://packaging.python.org/guides/single-sourcing-package-version/

- Have a `contextily/_version.py` file that defines it and that is read by both placed (eg see https://github.com/uwescience/shablona)
- Use a tool like [bumpversion](https://github.com/peritus/bumpversion) to do this automatically
- Use a tool to do this automatically based on git tags (eg [versioneer](https://github.com/warner/python-versioneer))


