### PR TITLE
Use README.md as description on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,14 @@ with open('requirements.txt') as f:
     tests_require = f.readlines()
 install_requires = [t.strip() for t in tests_require]
 
+with open('README.md') as f:
+    long_description = f.read()
+
 setup(name='contextily',
       version='0.99.0',
       description='Context geo-tiles in Python',
+      long_description=long_description,
+      long_description_content_type='text/markdown',
       url='https://github.com/darribas/contextily',
       author='Dani Arribas-Bel',
       author_email='daniel.arribas.bel@gmail.com',


### PR DESCRIPTION
Right now https://pypi.org/project/contextily/ looks like:

![image](https://user-images.githubusercontent.com/1324225/43122227-f5efae42-8f28-11e8-87f2-3d0676c3e614.png)

The good news is the new PyPI (aka Warehouse) now supports Markdown for the description, so we can put README.md in there without conversion!

For more info and examples:
* https://pypi.org/project/markdown-description-example/
* https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
* https://github.com/di/markdown-description-example
