### PR TITLE
COMPAT: use numpy searchsorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ the internet into geospatial raster files. Bounding boxes can be passed in both 
 
 * `mercantile`
 * `numpy`
-* `pandas`
 - `matplotlib`
 * `pillow`
 * `rasterio`

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -6,7 +6,6 @@ import requests
 import io
 import os
 import numpy as np
-import pandas as pd
 import rasterio as rio
 from PIL import Image
 from rasterio.transform import from_origin

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -260,13 +260,13 @@ def bb2wdw(bb, rtr):
               ((row_start, row_stop), (col_start, col_stop))
     '''
     rbb = rtr.bounds
-    xi = pd.Series(np.linspace(rbb.left, rbb.right, rtr.shape[1]))
-    yi = pd.Series(np.linspace(rbb.bottom, rbb.top, rtr.shape[0]))
+    xi = np.linspace(rbb.left, rbb.right, rtr.shape[1])
+    yi = np.linspace(rbb.bottom, rbb.top, rtr.shape[0])
 
-    window = ((rtr.shape[0] - yi.searchsorted(bb[3])[0],
-              rtr.shape[0] - yi.searchsorted(bb[1])[0]),
-              (xi.searchsorted(bb[0])[0],
-               xi.searchsorted(bb[2])[0])
+    window = ((rtr.shape[0] - yi.searchsorted(bb[3]),
+              rtr.shape[0] - yi.searchsorted(bb[1])),
+              (xi.searchsorted(bb[0]),
+               xi.searchsorted(bb[2]))
               )
     return window
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 geopy
 matplotlib
 mercantile
-pandas
 pillow
 pytest
 rasterio


### PR DESCRIPTION
Because it is not needed + to overcome pandas API change in 0.24.0
to return scalar instead of 1-element array

Noticed when I was running the tests for the other PR using pandas master. Related change in pandas is https://github.com/pandas-dev/pandas/pull/23801