### PR TITLE
Move request handling outside of bounds2img function

### DIFF
--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -150,10 +150,7 @@ def bounds2img(w, s, e, n, zoom='auto',
         x, y, z = t.x, t.y, t.z
         tile_url = url.replace('tileX', str(x)).replace('tileY', str(y)).replace('tileZ', str(z))
         # ---
-        request = _retryer(tile_url, wait, max_retries)
-        with io.BytesIO(request.content) as image_stream:
-            image = Image.open(image_stream).convert('RGB')
-            image = np.asarray(image)
+        image = _fetch_tile(tile_url, wait, max_retries)
         # ---
         wt, st, et, nt = mt.bounds(t)
         xr = np.linspace(wt, et, image.shape[0])
@@ -166,6 +163,14 @@ def bounds2img(w, s, e, n, zoom='auto',
     e, n = mt.xy(maxX, maxY)
     extent = w, e, s, n
     return merged[::-1], extent
+
+
+def _fetch_tile(tile_url, wait, max_retries):
+    request = _retryer(tile_url, wait, max_retries)
+    with io.BytesIO(request.content) as image_stream:
+        image = Image.open(image_stream).convert('RGB')
+        image = np.asarray(image)
+    return image
 
 
 def _retryer(tile_url, wait, max_retries):


### PR DESCRIPTION
Tiny refactor to move request to image conversion outside of `bounds2img`.