### PR TITLE
Move pytest to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 pip
+pytest
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@ matplotlib
 mercantile
 pandas
 pillow
-pytest
 rasterio
 requests


### PR DESCRIPTION
Pytest is only a testing (dev) requirement, so is not needed to have in the hard requirements.