### PR TITLE
Add caching of tiles with CacheControl package for requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ the internet into geospatial raster files. Bounding boxes can be passed in both 
 * `pillow`
 * `rasterio`
 * `requests`
+* `CacheControl`
 * `geopy`
 
 ## Installation

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -3,6 +3,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import mercantile as mt
 import requests
+from cachecontrol import CacheControl
 import io
 import os
 import numpy as np
@@ -13,6 +14,9 @@ from . import tile_providers as sources
 
 
 __all__ = ['bounds2raster', 'bounds2img', 'howmany']
+
+
+cached_session = CacheControl(requests.session())
 
 
 def bounds2raster(w, s, e, n, path, zoom='auto',
@@ -186,7 +190,7 @@ def _retryer(tile_url, wait, max_retries):
     request object containing the web response.
     """
     try:
-        request = requests.get(tile_url)
+        request = cached_session.get(tile_url)
         request.raise_for_status()
     except requests.HTTPError:
         if request.status_code == 404:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+CacheControl
 geopy
 matplotlib
 mercantile


### PR DESCRIPTION
Closes #46

I went with the CacheControl package (https://cachecontrol.readthedocs.io/en/latest/), as this seemed the best fit since we already use requests (and it is recommended for caching by the requests docs).

For now I didn't use any specific persistent file cache, which means the caching only happens in memory and thus only within one session (so restarting python does not keep the cache). I think that's at least a good enough start.

Since it is only for that python session, I don't we already need some functionality like `reset_cache()`, as you can also just restart your python kernel to achieve that.