### PR TITLE
use Miniconda3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,10 @@ before_install:
   - ./miniconda.sh -b -p ./miniconda
   - export PATH=`pwd`/miniconda/bin:$PATH
   - conda update --yes conda
-  - conda config --add channels conda-forge #--force
+  - conda config --add channels conda-forge --force
   - conda config --set channel_priority strict
   - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
   - source activate TEST
-  - conda install --yes rasterio 
   - pip install coveralls
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ before_install:
   - conda config --add channels conda-forge #--force
   - conda config --set channel_priority strict
   - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
-  - conda install --yes rasterio 
   - source activate TEST
+  - conda install --yes rasterio 
   - pip install coveralls
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - ./miniconda.sh -b -p ./miniconda
   - export PATH=`pwd`/miniconda/bin:$PATH
   - conda update --yes conda
-  - conda config --add channels conda-forge --force
+  - conda config --add channels conda-forge #--force
   - conda config --set channel_priority strict
   - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
   - source activate TEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ python:
   - 3.5
   - 3.6
 before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh; fi
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p ./miniconda
   - export PATH=`pwd`/miniconda/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - export PATH=`pwd`/miniconda/bin:$PATH
   - conda update --yes conda
   - conda config --add channels conda-forge #--force
-  - conda config --set channel_priority strict
+  #- conda config --set channel_priority strict
   - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
   - source activate TEST
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ before_install:
   - export PATH=`pwd`/miniconda/bin:$PATH
   - conda update --yes conda
   - conda config --add channels conda-forge #--force
-  #- conda config --set channel_priority strict
+  - conda config --set channel_priority strict
   - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
+  - conda install --yes rasterio 
   - source activate TEST
   - pip install coveralls
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - export PATH=`pwd`/miniconda/bin:$PATH
   - conda update --yes conda
   - conda config --add channels conda-forge --force
+  - conda config --set channel_priority strict
   - conda create --yes -n TEST python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
   - source activate TEST
   - pip install coveralls

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ geopy
 matplotlib
 mercantile
 pillow
+rasterio
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ geopy
 matplotlib
 mercantile
 pillow
-rasterio
 requests


### PR DESCRIPTION
Addressing #62 (see also pysal/splot#48)

Since there is no more support for `Python2`, is there a specific reason to perform TravisCI environment builds with `Miniconda2`? This PR addresses that issue and includes the new `conda` feature:

 `- conda config --set channel_priority strict`.