### PR TITLE
Use standard urls with {x} instead of 'tileX'  + deprecate old format

### DIFF
--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -147,10 +147,8 @@ def bounds2img(w, s, e, n, zoom='auto',
     arrays = []
     for t in mt.tiles(w, s, e, n, [zoom]):
         x, y, z = t.x, t.y, t.z
-        tile_url = url.replace('tileX', str(x)).replace('tileY', str(y)).replace('tileZ', str(z))
-        # ---
+        tile_url = _construct_tile_url(url, x, y, z)
         image = _fetch_tile(tile_url, wait, max_retries)
-        # ---
         tiles.append(t)
         arrays.append(image)
     merged, extent = _merge_tiles(tiles, arrays)
@@ -160,6 +158,14 @@ def bounds2img(w, s, e, n, zoom='auto',
     right, top = mt.xy(east, north)
     extent = left, right, bottom, top
     return merged, extent
+
+
+def _construct_tile_url(url, x, y, z):
+    """
+    Generate actual tile url from tile provider definition or template url.
+    """
+    tile_url = url.replace('tileX', str(x)).replace('tileY', str(y)).replace('tileZ', str(z))
+    return tile_url
 
 
 def _fetch_tile(tile_url, wait, max_retries):

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -5,6 +5,7 @@ import mercantile as mt
 import requests
 import io
 import os
+import warnings
 import numpy as np
 import rasterio as rio
 from PIL import Image
@@ -164,7 +165,13 @@ def _construct_tile_url(url, x, y, z):
     """
     Generate actual tile url from tile provider definition or template url.
     """
-    tile_url = url.replace('tileX', str(x)).replace('tileY', str(y)).replace('tileZ', str(z))
+    if 'tileX' in url and 'tileY' in url:
+        warnings.warn(
+            "The url format using 'tileX', 'tileY', 'tileZ' as placeholders "
+            "is deprecated. Please use '{x}', '{y}', '{z}' instead.",
+            FutureWarning)
+        url = url.replace('tileX', '{x}').replace('tileY', '{y}').replace('tileZ', '{z}')
+    tile_url = url.format(x=x, y=y, z=z)
     return tile_url
 
 

--- a/contextily/tile_providers.py
+++ b/contextily/tile_providers.py
@@ -2,21 +2,21 @@
 
 ### Tile provider sources ###
 
-ST_TONER = 'http://tile.stamen.com/toner/tileZ/tileX/tileY.png'
-ST_TONER_HYBRID = 'http://tile.stamen.com/toner-hybrid/tileZ/tileX/tileY.png'
-ST_TONER_LABELS = 'http://tile.stamen.com/toner-labels/tileZ/tileX/tileY.png'
-ST_TONER_LINES = 'http://tile.stamen.com/toner-lines/tileZ/tileX/tileY.png'
-ST_TONER_BACKGROUND = 'http://tile.stamen.com/toner-background/tileZ/tileX/tileY.png'
-ST_TONER_LITE = 'http://tile.stamen.com/toner-lite/tileZ/tileX/tileY.png'
+ST_TONER = 'http://tile.stamen.com/toner/{z}/{x}/{y}.png'
+ST_TONER_HYBRID = 'http://tile.stamen.com/toner-hybrid/{z}/{x}/{y}.png'
+ST_TONER_LABELS = 'http://tile.stamen.com/toner-labels/{z}/{x}/{y}.png'
+ST_TONER_LINES = 'http://tile.stamen.com/toner-lines/{z}/{x}/{y}.png'
+ST_TONER_BACKGROUND = 'http://tile.stamen.com/toner-background/{z}/{x}/{y}.png'
+ST_TONER_LITE = 'http://tile.stamen.com/toner-lite/{z}/{x}/{y}.png'
 
-ST_TERRAIN = 'http://tile.stamen.com/terrain/tileZ/tileX/tileY.png'
-ST_TERRAIN_LABELS = 'http://tile.stamen.com/terrain-labels/tileZ/tileX/tileY.png'
-ST_TERRAIN_LINES = 'http://tile.stamen.com/terrain-lines/tileZ/tileX/tileY.png'
-ST_TERRAIN_BACKGROUND = 'http://tile.stamen.com/terrain-background/tileZ/tileX/tileY.png'
+ST_TERRAIN = 'http://tile.stamen.com/terrain/{z}/{x}/{y}.png'
+ST_TERRAIN_LABELS = 'http://tile.stamen.com/terrain-labels/{z}/{x}/{y}.png'
+ST_TERRAIN_LINES = 'http://tile.stamen.com/terrain-lines/{z}/{x}/{y}.png'
+ST_TERRAIN_BACKGROUND = 'http://tile.stamen.com/terrain-background/{z}/{x}/{y}.png'
 
-ST_WATERCOLOR = 'http://tile.stamen.com/watercolor/tileZ/tileX/tileY.png'
+ST_WATERCOLOR = 'http://tile.stamen.com/watercolor/{z}/{x}/{y}.png'
 
 # OpenStreetMap as an alternative
-OSM_A = 'http://a.tile.openstreetmap.org/tileZ/tileX/tileY.png'
-OSM_B = 'http://b.tile.openstreetmap.org/tileZ/tileX/tileY.png'
-OSM_C = 'http://c.tile.openstreetmap.org/tileZ/tileX/tileY.png'
+OSM_A = 'http://a.tile.openstreetmap.org/{z}/{x}/{y}.png'
+OSM_B = 'http://b.tile.openstreetmap.org/{z}/{x}/{y}.png'
+OSM_C = 'http://c.tile.openstreetmap.org/{z}/{x}/{y}.png'

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,11 +1,29 @@
 import contextily as ctx
 import contextily.tile_providers as tilers
 
+import pytest
+from numpy.testing import assert_allclose
+
+
 def test_sources():
     # NOTE: only tests they download, does not check pixel values
-    w, s, e, n = (-106.6495132446289, 25.845197677612305, 
-            -93.50721740722656, 36.49387741088867)
+    w, s, e, n = (-106.6495132446289, 25.845197677612305,
+                  -93.50721740722656, 36.49387741088867)
     sources = [i for i in dir(tilers) if i[0] != '_']
     for src in sources:
-        img, ext = ctx.bounds2img(w, s, e, n, 4, ll=True)
+        img, ext = ctx.bounds2img(w, s, e, n, 4, url=getattr(tilers, src), ll=True)
 
+
+def test_deprecated_url_format():
+    old_url = 'http://a.tile.openstreetmap.org/tileZ/tileX/tileY.png'
+    new_url = 'http://a.tile.openstreetmap.org/{z}/{x}/{y}.png'
+
+    w, s, e, n = (-106.6495132446289, 25.845197677612305,
+                  -93.50721740722656, 36.49387741088867)
+
+    with pytest.warns(FutureWarning, match="The url format using 'tileX'"):
+        img1, ext1 = ctx.bounds2img(w, s, e, n, 4, url=old_url, ll=True)
+
+    img2, ext2 = ctx.bounds2img(w, s, e, n, 4, url=new_url, ll=True)
+    assert_allclose(img1, img2)
+    assert_allclose(ext1, ext2)


### PR DESCRIPTION
Closes https://github.com/darribas/contextily/issues/60