### PR TITLE
Add option to catch tiles locally without additional requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ build/
 dist/
 .coverage
 .pytest_cache/
+
+# IDE
+.idea

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -172,11 +172,16 @@ def bounds2img(w, s, e, n, zoom='auto',
 
 def _fetch_tile_with_cache(tile_url, wait, max_retries, path):
     """
-    Fetch local tile or try to download file if local file is not present.
+    Fetch local tile from cache or try to download tile into cache if tile does
+    not exist.
 
     Sometimes OSM servers deny requests via Python scripts but allows direct
-    downloads. In that case one can try to download the file manually using the
-    given url and filename.
+    downloads. In that case one can try to download the tiles manually and copy
+    them using the cache name pattern. Remove 'http://' or 'https://' and
+    replace all slashes by underscores:
+
+    https://a.tile.openstreetmap.fr/osmfr/17/68848/41966.png
+    a.tile.openstreetmap.fr_osmfr_17_68848_41966.png
     """
 
     fn = tile_url.replace('https://', '').replace('http://', '')

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -95,7 +95,7 @@ def bounds2raster(w, s, e, n, path, zoom='auto',
 def bounds2img(w, s, e, n, zoom='auto',
                url=sources.ST_TERRAIN, path=None, ll=False,
                wait=0, max_retries=2):
-    """
+    '''
     Take bounding box and zoom and return an image with all the tiles
     that compose the map and its Spherical Mercator extent.
 
@@ -114,8 +114,7 @@ def bounds2img(w, s, e, n, zoom='auto',
     zoom    : int
               Level of detail
     url     : str
-              [Optional. Default:
-              'http://tile.stamen.com/terrain/tileZ/tileX/tileY.png']
+              [Optional. Default: 'http://tile.stamen.com/terrain/tileZ/tileX/tileY.png']
               URL for tile provider. The placeholders for the XYZ need to be
               `tileX`, `tileY`, `tileZ`, respectively. IMPORTANT: tiles are
               assumed to be in the Spherical Mercator projection (EPSG:3857).
@@ -142,7 +141,7 @@ def bounds2img(w, s, e, n, zoom='auto',
               Image as a 3D array of RGB values
     extent  : tuple
               Bounding box [minX, maxX, minY, maxY] of the returned image
-    """
+    '''
     if not ll:
         # Convert w, s, e, n into lon/lat
         w, s = _sm2ll(w, s)
@@ -232,17 +231,15 @@ def _retryer(tile_url, wait, max_retries):
         request.raise_for_status()
     except requests.HTTPError:
         if request.status_code == 404:
-            raise requests.HTTPError(
-                'Tile URL resulted in a 404 error. '
-                'Double-check your tile url:\n{}'.format(tile_url))
+            raise requests.HTTPError('Tile URL resulted in a 404 error. '
+                                     'Double-check your tile url:\n{}'.format(tile_url))
         elif request.status_code == 104:
             if max_retries > 0:
                 os.wait(wait)
                 max_retries -= 1
                 request = _retryer(tile_url, wait, max_retries)
             else:
-                raise requests.HTTPError(
-                    'Connection reset by peer too many times.')
+                raise requests.HTTPError('Connection reset by peer too many times.')
     return request
 
 

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -95,7 +95,7 @@ def bounds2raster(w, s, e, n, path, zoom='auto',
 def bounds2img(w, s, e, n, zoom='auto',
                url=sources.ST_TERRAIN, path=None, ll=False,
                wait=0, max_retries=2):
-    '''
+    """
     Take bounding box and zoom and return an image with all the tiles
     that compose the map and its Spherical Mercator extent.
 
@@ -114,7 +114,8 @@ def bounds2img(w, s, e, n, zoom='auto',
     zoom    : int
               Level of detail
     url     : str
-              [Optional. Default: 'http://tile.stamen.com/terrain/tileZ/tileX/tileY.png']
+              [Optional. Default:
+              'http://tile.stamen.com/terrain/tileZ/tileX/tileY.png']
               URL for tile provider. The placeholders for the XYZ need to be
               `tileX`, `tileY`, `tileZ`, respectively. IMPORTANT: tiles are
               assumed to be in the Spherical Mercator projection (EPSG:3857).
@@ -141,7 +142,7 @@ def bounds2img(w, s, e, n, zoom='auto',
               Image as a 3D array of RGB values
     extent  : tuple
               Bounding box [minX, maxX, minY, maxY] of the returned image
-    '''
+    """
     if not ll:
         # Convert w, s, e, n into lon/lat
         w, s = _sm2ll(w, s)
@@ -238,15 +239,17 @@ def _retryer(tile_url, wait, max_retries):
         request.raise_for_status()
     except requests.HTTPError:
         if request.status_code == 404:
-            raise requests.HTTPError('Tile URL resulted in a 404 error. '
-                                     'Double-check your tile url:\n{}'.format(tile_url))
+            raise requests.HTTPError(
+                'Tile URL resulted in a 404 error. '
+                'Double-check your tile url:\n{}'.format(tile_url))
         elif request.status_code == 104:
             if max_retries > 0:
                 os.wait(wait)
                 max_retries -= 1
                 request = _retryer(tile_url, wait, max_retries)
             else:
-                raise requests.HTTPError('Connection reset by peer too many times.')
+                raise requests.HTTPError(
+                    'Connection reset by peer too many times.')
     return request
 
 

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -198,8 +198,8 @@ def _fetch_tile_with_cache(tile_url, wait, max_retries, path):
     them using the cache name pattern. Remove 'http://' or 'https://' and
     replace all slashes by underscores:
 
-    https://a.tile.openstreetmap.fr/osmfr/17/68848/41966.png
-    a.tile.openstreetmap.fr_osmfr_17_68848_41966.png
+    URL: https://a.tile.openstreetmap.fr/osmfr/17/68848/41966.png
+    FILE: a.tile.openstreetmap.fr_osmfr_17_68848_41966.png
     """
 
     fn = tile_url.replace('https://', '').replace('http://', '')

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -15,7 +15,7 @@ from rasterio.transform import from_origin
 from . import tile_providers as sources
 
 
-__all__ = ['bounds2raster', 'bounds2img', 'howmany']
+__all__ = ['bounds2raster', 'bounds2img', 'howmany', 'empty_tile_cache']
 
 
 USER_AGENT = 'contextily-' + uuid.uuid4().hex
@@ -263,6 +263,21 @@ def _retryer(tile_url, wait, max_retries):
             else:
                 raise requests.HTTPError('Connection reset by peer too many times.')
     return request
+
+
+def empty_tile_cache(cache_dir):
+    """
+    Remove all tiles from the given cache directory.
+
+    Parameters
+    ----------
+    cache_dir : str
+        Path to the cache directory.
+        
+    """
+    for root, dirs, files in os.walk(cache_dir):
+        for f in files:
+            os.unlink(os.path.join(root, f))
 
 
 def howmany(w, s, e, n, zoom, verbose=True, ll=False):

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -286,6 +286,21 @@ def _retryer(tile_url, wait, max_retries):
     return request
 
 
+def empty_tile_cache(cache_dir):
+    """
+    Remove all tiles from the given cache directory.
+
+    Parameters
+    ----------
+    cache_dir : str
+        Path to the cache directory.
+
+    """
+    for root, dirs, files in os.walk(cache_dir):
+        for f in files:
+            os.unlink(os.path.join(root, f))
+
+
 def howmany(w, s, e, n, zoom, verbose=True, ll=False):
     '''
     Number of tiles required for a given bounding box and a zoom level

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -152,8 +152,7 @@ def bounds2img(w, s, e, n, zoom='auto',
     arrays = []
     for t in mt.tiles(w, s, e, n, [zoom]):
         x, y, z = t.x, t.y, t.z
-        tile_url = url.replace(
-            'tileX', str(x)).replace('tileY', str(y)).replace('tileZ', str(z))
+        tile_url = url.replace('tileX', str(x)).replace('tileY', str(y)).replace('tileZ', str(z))
         # ---
         if path is not None:
             image = _fetch_tile_with_cache(tile_url, wait, max_retries, path)

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -61,21 +61,15 @@ def test_bounds2img():
     assert img[100, 200, :].tolist() == [156, 180, 131]
     assert img[200, 100, :].tolist() == [230, 225, 189]
 
+
 def test_bounds2img_with_cache():
     w, s, e, n = (-106.6495132446289, 25.845197677612305,
                   -93.50721740722656, 36.49387741088867)
     # download tile
-    p = os.path.expanduser('~')
-    img, ext = ctx.bounds2img(w, s, e, n, cache_dir=p, zoom=4, ll=True)
-    solu = (-12523442.714243276,
-            -10018754.171394622,
-            2504688.5428486555,
-            5009377.085697309)
-    for i, j in zip(ext, solu):
-        assert round(i - j, TOL) == 0
-    assert img[100, 100, :].tolist() == [230, 229, 188]
-    assert img[100, 200, :].tolist() == [156, 180, 131]
-    assert img[200, 100, :].tolist() == [230, 225, 189]
+    p = os.path.join(os.path.expanduser('~'), 'contextily_test_cache')
+    ctx.bounds2img(w, s, e, n, cache_dir=p, zoom=4, ll=True)
+
+    assert list(os.listdir(p)) == ['tile.stamen.com_terrain_4_3_6.png']
 
     # fetch from cache
     img, ext = ctx.bounds2img(w, s, e, n, cache_dir=p, zoom=4, ll=True)
@@ -88,8 +82,11 @@ def test_bounds2img_with_cache():
     assert img[100, 100, :].tolist() == [230, 229, 188]
     assert img[100, 200, :].tolist() == [156, 180, 131]
     assert img[200, 100, :].tolist() == [230, 225, 189]
-    os.remove(os.path.join(os.path.expanduser('~'),
-                           'tile.stamen.com_terrain_4_3_6.png'))
+
+    ctx.empty_tile_cache(p)
+    assert list(os.listdir(p)) != ['tile.stamen.com_terrain_4_3_6.png']
+    os.removedirs(p)
+
 
 def test_howmany():
     w, s, e, n = (-106.6495132446289, 25.845197677612305,

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -66,7 +66,7 @@ def test_bounds2img_with_cache():
                   -93.50721740722656, 36.49387741088867)
     # download tile
     p = os.path.expanduser('~')
-    img, ext = ctx.bounds2img(w, s, e, n, path=p, zoom=4, ll=True)
+    img, ext = ctx.bounds2img(w, s, e, n, cache_dir=p, zoom=4, ll=True)
     solu = (-12523442.714243276,
             -10018754.171394622,
             2504688.5428486555,
@@ -78,7 +78,7 @@ def test_bounds2img_with_cache():
     assert img[200, 100, :].tolist() == [230, 225, 189]
 
     # fetch from cache
-    img, ext = ctx.bounds2img(w, s, e, n, path=p, zoom=4, ll=True)
+    img, ext = ctx.bounds2img(w, s, e, n, cache_dir=p, zoom=4, ll=True)
     solu = (-12523442.714243276,
             -10018754.171394622,
             2504688.5428486555,

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -61,6 +61,36 @@ def test_bounds2img():
     assert img[100, 200, :].tolist() == [156, 180, 131]
     assert img[200, 100, :].tolist() == [230, 225, 189]
 
+def test_bounds2img_with_cache():
+    w, s, e, n = (-106.6495132446289, 25.845197677612305,
+                  -93.50721740722656, 36.49387741088867)
+    # download tile
+    p = os.path.expanduser('~')
+    img, ext = ctx.bounds2img(w, s, e, n, path=p, zoom=4, ll=True)
+    solu = (-12523442.714243276,
+            -10018754.171394622,
+            2504688.5428486555,
+            5009377.085697309)
+    for i, j in zip(ext, solu):
+        assert round(i - j, TOL) == 0
+    assert img[100, 100, :].tolist() == [230, 229, 188]
+    assert img[100, 200, :].tolist() == [156, 180, 131]
+    assert img[200, 100, :].tolist() == [230, 225, 189]
+
+    # fetch from cache
+    img, ext = ctx.bounds2img(w, s, e, n, path=p, zoom=4, ll=True)
+    solu = (-12523442.714243276,
+            -10018754.171394622,
+            2504688.5428486555,
+            5009377.085697309)
+    for i, j in zip(ext, solu):
+        assert round(i - j, TOL) == 0
+    assert img[100, 100, :].tolist() == [230, 229, 188]
+    assert img[100, 200, :].tolist() == [156, 180, 131]
+    assert img[200, 100, :].tolist() == [230, 225, 189]
+    os.remove(os.path.join(os.path.expanduser('~'),
+                           'tile.stamen.com_terrain_4_3_6.png'))
+
 def test_howmany():
     w, s, e, n = (-106.6495132446289, 25.845197677612305,
             -93.50721740722656, 36.49387741088867)


### PR DESCRIPTION
Some server reject requests from python scripts. In my case this happened when I try to use the default OSM tile server. But I was able to download the tile via the web-browser.

https://a.tile.openstreetmap.org/tileZ/tileX/tileY.png

Therefore, I added an option to download the tiles manually (using the web-browser) and use the local files afterwards.

In case the server responses normally the tiles will be downloaded automatically and the local tiles will be used the next run. This will speed up the process and reduces server usage.

You can use this function by passing a path name where the files will be stored. If you do not pass a path name everything will remain as it is now.

If you like the idea I could add tests. Feel free to correct typos, I am not a native speaker. 