### PR TITLE
ENH: use joblib for caching result of fetch_tile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ the internet into geospatial raster files. Bounding boxes can be passed in both 
 * `rasterio`
 * `requests`
 * `geopy`
+* `joblib`
 
 ## Installation
 

--- a/ci/travis/36-minimal.yaml
+++ b/ci/travis/36-minimal.yaml
@@ -10,6 +10,7 @@ dependencies:
   - pillow
   - rasterio
   - requests
+  - joblib
   # testing
   - pip
   - pytest

--- a/ci/travis/37-latest-conda-forge.yaml
+++ b/ci/travis/37-latest-conda-forge.yaml
@@ -10,6 +10,7 @@ dependencies:
   - pillow
   - rasterio
   - requests
+  - joblib
   # testing
   - pip
   - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mercantile
 pillow
 rasterio
 requests
+joblib


### PR DESCRIPTION
@darribas @ljwolf here the version based on joblib, alternative for https://github.com/darribas/contextily/pull/57, https://github.com/darribas/contextily/pull/68, or https://github.com/darribas/contextily/pull/79

Within a session, you can do `contextily.tile.memory.clear()` to empty the cache.

With the current version, it is not possible to do something like:

```
import contextily
import joblib

contextily.tile.memory = joblib.Memory('/my/custom/dir')
```

to be able to keep the cache alive across sessions (currently I delete the temporary directory at the end of every python session). 
The reason for that is because it is decorating the `_fetch_tile` function, and overwriting the memory object is not changing the decorated function .. (probably this could be avoided with some effort, not fully sure).

I am not yet fully sure I find this necessarily better than https://github.com/darribas/contextily/pull/57
Closes https://github.com/darribas/contextily/issues/46