### PR TITLE
API: change add_basemap to not return the received ax object

### DIFF
--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -88,7 +88,7 @@ def add_basemap(
     Add a web basemap:
 
     >>> ax = db.plot(alpha=0.5, color='k', figsize=(6, 6))
-    >>> ax = ctx.add_basemap(ax, url=url)
+    >>> ctx.add_basemap(ax, url=url)
     >>> plt.show()
 
     Or download a basemap to a local file and then plot it:
@@ -96,7 +96,7 @@ def add_basemap(
     >>> url = 'virginia.tiff'
     >>> _ = ctx.bounds2raster(*db.total_bounds, zoom=6, path=url)
     >>> ax = db.plot(alpha=0.5, color='k', figsize=(6, 6))
-    >>> ax = ctx.add_basemap(ax, url=url)
+    >>> ctx.add_basemap(ax, url=url)
     >>> plt.show()
 
     """
@@ -141,7 +141,9 @@ def add_basemap(
         bb = raster.bounds
         extent = bb.left, bb.right, bb.bottom, bb.top
     # Plotting
-    ax.imshow(image, extent=extent, interpolation=interpolation, **extra_imshow_args)
+    img = ax.imshow(
+        image, extent=extent, interpolation=interpolation, **extra_imshow_args
+    )
 
     if reset_extent:
         ax.axis((xmin, xmax, ymin, ymax))
@@ -149,7 +151,7 @@ def add_basemap(
     if attribution:
         add_attribution(ax, attribution, font_size=attribution_size)
 
-    return ax
+    return img
 
 
 def _reproj_bb(left, right, bottom, top, s_crs, t_crs):

--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -76,12 +76,6 @@ def add_basemap(
     **extra_imshow_args : dict
                           Other parameters to be passed to `imshow`.
 
-    Returns
-    -------
-    ax                  : AxesSubplot
-                          Matplotlib axis with `x_lim` and `y_lim` set in Web
-                          Mercator (EPSG=3857) containing the basemap
-
     Example
     -------
 
@@ -159,7 +153,7 @@ def add_basemap(
     if attribution:
         add_attribution(ax, attribution, font_size=attribution_size)
 
-    return img
+    return
 
 
 def _reproj_bb(left, right, bottom, top, s_crs, t_crs):

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -241,7 +241,7 @@ def test_add_basemap():
     fig, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
-    ax = ctx.add_basemap(ax, zoom=10)
+    ctx.add_basemap(ax, zoom=10)
 
     # ensure add_basemap did not change the axis limits of ax
     ax_extent = (x1, x2, y1, y2)
@@ -256,7 +256,7 @@ def test_add_basemap():
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
     loc = ctx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
-    ax = ctx.add_basemap(ax, url="./test2.tif")
+    ctx.add_basemap(ax, url="./test2.tif")
 
     raster_extent = (
         -11740803.981631357,
@@ -273,7 +273,7 @@ def test_add_basemap():
     f, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
-    ax = ctx.add_basemap(ax, zoom="auto")
+    ctx.add_basemap(ax, zoom="auto")
 
     ax_extent = (
         -11740727.544603072,
@@ -292,7 +292,7 @@ def test_add_basemap():
     f, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
-    ax = ctx.add_basemap(ax, crs={"init": "epsg:4326"}, attribution=None)
+    ctx.add_basemap(ax, crs={"init": "epsg:4326"}, attribution=None)
     assert ax.get_xlim() == (x1, x2)
     assert ax.get_ylim() == (y1, y2)
     assert ax.images[0].get_array().sum() == 724238693
@@ -303,9 +303,7 @@ def test_add_basemap():
     f, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
-    ax = ctx.add_basemap(
-        ax, url="./test2.tif", crs={"init": "epsg:4326"}, attribution=None
-    )
+    ctx.add_basemap(ax, url="./test2.tif", crs={"init": "epsg:4326"}, attribution=None)
     assert ax.get_xlim() == (x1, x2)
     assert ax.get_ylim() == (y1, y2)
     assert ax.images[0].get_array().sum() == 724238693


### PR DESCRIPTION
This is a proposal to change the return value of `add_basemap` from `ax` to the Image artist created by the function. Some reasoning (as it is a breaking change):

- returning `ax` is useless (you already pass the ax objects, so you already have this object named) and also potentially confusing (is this a different ax than the one passed in?)
- sometimes it can be useful to have the matplotlib artist object that was created (eg for eg for adding a colorbar for it, although that is not relevant for tile backgrounds, but there might be other things as well). 
  You can get this eg by inspecting `ax.get_children()`, but that is always a bit tricky. Having it returned from the function is easier (and in 99% of the cases the user can simply ignore this return value anyway). 
- at some point this is what Thomas Caswell (matplotlib lead developer) recommended for functions extending matplotlib / addings things to a plot: accepting an ax, returning the created artists. And it is also what many matplotlib's methods do (eg `ax.imshow`).

(one question might be if we also want to return the Text artist from the attribution)