### PR TITLE
ENH: wrap attribution text

### DIFF
--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -182,14 +182,14 @@ def add_attribution(ax, att=ATTRIBUTION, font_size=ATTRIBUTION_SIZE):
     minX, maxX = ax.get_xlim()
     minY, maxY = ax.get_ylim()
     txt = ax.text(
-            minX + (maxX - minX) * 0.005,
-            minY + (maxY - minY) * 0.005,
-            att,
-            size=font_size,
-            path_effects=[patheffects.withStroke(linewidth=2, foreground="w")],
-            wrap=True
-        )
+        minX + (maxX - minX) * 0.005,
+        minY + (maxY - minY) * 0.005,
+        att,
+        size=font_size,
+        path_effects=[patheffects.withStroke(linewidth=2, foreground="w")],
+        wrap=True,
+    )
     bb = ax.get_window_extent()
     wrap_width = (bb.x1 - bb.x0) - (bb.x1 - bb.x0) * 0.1
-    txt._get_wrap_line_width = lambda : wrap_width
+    txt._get_wrap_line_width = lambda: wrap_width
     return ax

--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -189,7 +189,8 @@ def add_attribution(ax, att=ATTRIBUTION, font_size=ATTRIBUTION_SIZE):
         path_effects=[patheffects.withStroke(linewidth=2, foreground="w")],
         wrap=True,
     )
-    bb = ax.get_window_extent()
-    wrap_width = (bb.x1 - bb.x0) - (bb.x1 - bb.x0) * 0.1
+    # hack to have the text wrapped in the ax extent, for some explanation see
+    # https://stackoverflow.com/questions/48079364/wrapping-text-not-working-in-matplotlib
+    wrap_width = ax.get_window_extent().width * 0.99
     txt._get_wrap_line_width = lambda: wrap_width
     return ax

--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -181,11 +181,15 @@ def add_attribution(ax, att=ATTRIBUTION, font_size=ATTRIBUTION_SIZE):
     """
     minX, maxX = ax.get_xlim()
     minY, maxY = ax.get_ylim()
-    ax.text(
-        minX + (maxX - minX) * 0.005,
-        minY + (maxY - minY) * 0.005,
-        att,
-        size=font_size,
-        path_effects=[patheffects.withStroke(linewidth=2, foreground="w")],
-    )
+    txt = ax.text(
+            minX + (maxX - minX) * 0.005,
+            minY + (maxY - minY) * 0.005,
+            att,
+            size=font_size,
+            path_effects=[patheffects.withStroke(linewidth=2, foreground="w")],
+            wrap=True
+        )
+    bb = ax.get_window_extent()
+    wrap_width = (bb.x1 - bb.x0) - (bb.x1 - bb.x0) * 0.1
+    txt._get_wrap_line_width = lambda : wrap_width
     return ax

--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -179,12 +179,11 @@ def add_attribution(ax, att=ATTRIBUTION, font_size=ATTRIBUTION_SIZE):
                           Matplotlib axis with `x_lim` and `y_lim` set in Web
                           Mercator (EPSG=3857) and attribution text added
     """
-    minX, maxX = ax.get_xlim()
-    minY, maxY = ax.get_ylim()
     txt = ax.text(
-        minX + (maxX - minX) * 0.005,
-        minY + (maxY - minY) * 0.005,
+        0.005,
+        0.005,
         att,
+        transform=ax.transAxes,
         size=font_size,
         path_effects=[patheffects.withStroke(linewidth=2, foreground="w")],
         wrap=True,


### PR DESCRIPTION
This provides a hack to wrap the text of the attribution.