### PR TITLE
updates example to work with renamed function

### DIFF
--- a/examples/plot_map.py
+++ b/examples/plot_map.py
@@ -46,8 +46,7 @@ ctx.plot_map(loc2, ax=axs[1])
 # You can also grab tile information directly from a bounding box + zoom level.
 # This is demoed below:
 
-zoom = ctx.calculate_zoom(loc.w, loc.s, loc.e, loc.n)
-im2, bbox = ctx.bounds2img(loc.w, loc.s, loc.e, loc.n, zoom=zoom, ll=True)
+im2, bbox = ctx.bounds2img(loc.w, loc.s, loc.e, loc.n, zoom=loc.zoom, ll=True)
 ctx.plot_map(im2, bbox, ax=axs[2], title="Boulder, CO")
 
 plt.show()

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -247,9 +247,9 @@ def test_add_basemap():
     ax_extent = (x1, x2, y1, y2)
     assert ax.axis() == ax_extent
 
-    assert ax.images[0].get_array().sum() == 75853866
-    assert ax.images[0].get_array().shape == (256, 512, 3)
-    assert_array_almost_equal(ax.images[0].get_array().mean(), 192.90635681152344)
+    assert ax.images[0].get_array().sum() == 34840247
+    assert ax.images[0].get_array().shape == (256, 256, 3)
+    assert_array_almost_equal(ax.images[0].get_array().mean(), 177.20665995279947)
 
     # Test local source
     f, ax = matplotlib.pyplot.subplots(1)
@@ -277,14 +277,14 @@ def test_add_basemap():
 
     ax_extent = (
         -11740727.544603072,
-        -11691807.846500559,
-        4852834.0517692715,
+        -11701591.786121061,
+        4852834.051769271,
         4891969.810251278,
     )
     assert_array_almost_equal(ax_extent, ax.images[0].get_extent())
-    assert ax.images[0].get_array().sum() == 723918764
-    assert ax.images[0].get_array().shape == (1024, 1280, 3)
-    assert_array_almost_equal(ax.images[0].get_array().mean(), 184.10206197102863)
+    assert ax.images[0].get_array().sum() == 563185119
+    assert ax.images[0].get_array().shape == (1024, 1024, 3)
+    assert_array_almost_equal(ax.images[0].get_array().mean(), 179.03172779083252)
 
     # Test on-th-fly warping
     x1, x2 = -105.5, -105.00

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -95,12 +95,13 @@ def test_warp_tiles():
     )
     img, ext = ctx.bounds2img(w, s, e, n, zoom=4, ll=True)
     wimg, wext = ctx.warp_tiles(img, ext)
-    assert wext == (
-        -112.54394531249996,
-        -90.07903186397023,
-        21.966726124122374,
-        41.013065787006276,
-    )
+    assert_array_almost_equal(np.array(wext), \
+                              np.array([-112.54394531249996,
+                                        -90.07903186397023,
+                                        21.966726124122374,
+                                        41.013065787006276
+                                        ])
+                              )
     assert wimg[100, 100, :].tolist() == [228, 221, 184]
     assert wimg[100, 200, :].tolist() == [213, 219, 177]
     assert wimg[200, 100, :].tolist() == [133, 130, 109]


### PR DESCRIPTION
It looks like `contextily.calculate_zoom` was changed to a private function, so I'm updating the example to work again.

BTW, contextily is so nice @darribas :)