### PR TITLE
Fix syntax error on Python 3.5 and wrong data type

### DIFF
--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -24,8 +24,7 @@ def add_basemap(
     reset_extent=True,
     crs=None,
     resampling=Resampling.bilinear,
-    **extra_imshow_args,
-):
+    **extra_imshow_args):
     """
     Add a (web/local) basemap to `ax`
     ...

--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -72,7 +72,7 @@ def add_basemap(
                           [Optional. Default=Resampling.bilinear] Resampling 
                           method for executing warping, expressed as a 
                           `rasterio.enums.Resampling` method
-    **extra_imshow_args : dict
+    **extra_imshow_args :
                           Other parameters to be passed to `imshow`.
 
     Example


### PR DESCRIPTION
1. On Python 3.5 the comma at the end of the constructor raises a `SyntaxError`.

2. The data type of the '**extra_imshow_args` is not dict but undefined or various or just empty.

3. Shouldn't it be named `extra_imshow_kwargs` as it collects "keyword arguments" and not unnamed "arguments". But this is not very important, so I did not changed by now. I can change it if you agree.