### PR TITLE
ENH: option to set cache dir to permanent directory

### DIFF
--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -23,13 +23,37 @@ from rasterio.enums import Resampling
 from . import tile_providers as sources
 from . import providers
 
-__all__ = ["bounds2raster", "bounds2img", "warp_tiles", "warp_img_transform", "howmany"]
+__all__ = [
+    "bounds2raster",
+    "bounds2img",
+    "warp_tiles",
+    "warp_img_transform",
+    "howmany",
+    "set_cache_dir",
+]
 
 
 USER_AGENT = "contextily-" + uuid.uuid4().hex
 
 tmpdir = tempfile.mkdtemp()
 memory = _Memory(tmpdir, verbose=0)
+
+
+def set_cache_dir(path):
+    """
+    Set a cache directory to use in the current python session.
+
+    By default, contextily caches downloaded tiles per python session, but
+    will afterwards delete the cache directory. By setting it to a custom
+    path, you can avoid this, and re-use the same cache a next time by
+    again setting the cache dir to that directory.
+
+    Parameters
+    ----------
+    path : str
+        Path to the cache directory.
+    """
+    memory.store_backend.location = path
 
 
 def _clear_cache():

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -361,3 +361,15 @@ def test_attribution():
     txt = ctx.add_attribution(ax, "Test", font_size=15, fontfamily="monospace")
     assert txt.get_size() == 15
     assert txt.get_fontfamily() == ["monospace"]
+
+
+def test_set_cache_dir(tmpdir):
+    # set cache directory manually
+    path = str(tmpdir.mkdir("cache"))
+    ctx.set_cache_dir(path)
+
+    # then check that plotting still works
+    extent = (-11945319, -10336026, 2910477, 4438236)
+    fig, ax = matplotlib.pyplot.subplots()
+    ax.axis(extent)
+    ctx.add_basemap(ax)


### PR DESCRIPTION
Closes https://github.com/darribas/contextily/issues/46

cc @uvchik 

For now, just added a function that the user can call as (and didn't add it in other places, like add_basemap):

```
contextily.set_cache_dir("/path/to/local/cache/")
```

I used `set_cache_dir`, but @uvchik made the suggestion to call it `use_cache` :

> I would name it `use_cache` because one has to execute it every time one wants to plot. For me 'set' indicates, that I have to execute it once. But I am not a native speaker and I am open to other names.

(note that this "every time one wants to plot is not "for every `add_basemap()` call", you only need to do it once in your python session (eg put it at the beginning of your script or notebook), but it is true that you still need to do it every time once per session, it's not a permanent setting that survives across python sessions. So `use_cache` might then indeed be better, no strong feeling here)


> I am not sure whether we should add a default value. 

Since by default it is not called, I think it is fine to have the `path` a required argument without default (as user will only call this function if they want to set a specific cache directory, by default, a temporary directory is created by contextily which is destroyed at the end of the python session).


