### PR TITLE
Deprecate URL option in favor of source argument

### DIFF
--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -24,8 +24,7 @@ from . import tile_providers as sources
 from . import providers
 from ._providers import TileProvider
 
-__all__ = ["bounds2raster", "bounds2img",
-           "warp_tiles", "warp_img_transform", "howmany"]
+__all__ = ["bounds2raster", "bounds2img", "warp_tiles", "warp_img_transform", "howmany"]
 
 
 USER_AGENT = "contextily-" + uuid.uuid4().hex
@@ -41,8 +40,19 @@ def _clear_cache():
 atexit.register(_clear_cache)
 
 
-def bounds2raster(w, s, e, n, path, zoom="auto", source=None,
-                  ll=False, wait=0, max_retries=2, url=None):
+def bounds2raster(
+    w,
+    s,
+    e,
+    n,
+    path,
+    zoom="auto",
+    source=None,
+    ll=False,
+    wait=0,
+    max_retries=2,
+    url=None,
+):
     """
     Take bounding box and zoom, and write tiles into a raster file in
     the Spherical Mercator CRS (EPSG:3857)
@@ -125,8 +135,9 @@ def bounds2raster(w, s, e, n, path, zoom="auto", source=None,
     return Z, ext
 
 
-def bounds2img(w, s, e, n, zoom="auto", source=None,
-               ll=False, wait=0, max_retries=2, url=None):
+def bounds2img(
+    w, s, e, n, zoom="auto", source=None, ll=False, wait=0, max_retries=2, url=None
+):
     """
     Take bounding box and zoom and return an image with all the tiles
     that compose the map and its Spherical Mercator extent.
@@ -179,13 +190,20 @@ def bounds2img(w, s, e, n, zoom="auto", source=None,
         w, s = _sm2ll(w, s)
         e, n = _sm2ll(e, n)
     if url is not None and source is None:
-        warnings.warn('The "url" option is deprecated. Please use the "source"'
-                      ' argument instead.', FutureWarning, stacklevel=2)
+        warnings.warn(
+            'The "url" option is deprecated. Please use the "source"'
+            " argument instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
         source = url
     elif url is not None and source is not None:
-        warnings.warn('The "url" argument is deprecated. Please use the "source"'
-                      ' argument. Do not supply a "url" argument. It will be ignored.',
-                      FutureWarning, stacklevel=2)
+        warnings.warn(
+            'The "url" argument is deprecated. Please use the "source"'
+            ' argument. Do not supply a "url" argument. It will be ignored.',
+            FutureWarning,
+            stacklevel=2,
+        )
     # get provider dict given the url
     provider = _process_source(source)
     # calculate and validate zoom level
@@ -222,8 +240,7 @@ def _url_from_string(url):
             FutureWarning,
         )
         url = (
-            url.replace("tileX", "{x}").replace(
-                "tileY", "{y}").replace("tileZ", "{z}")
+            url.replace("tileX", "{x}").replace("tileY", "{y}").replace("tileZ", "{z}")
         )
     return {"url": url}
 
@@ -234,8 +251,9 @@ def _process_source(source):
     elif isinstance(source, str):
         provider = _url_from_string(source)
     elif not isinstance(source, (dict, TileProvider)):
-        raise TypeError("The 'url' needs to be a contextily.providers object,"
-                        " a dict, or string")
+        raise TypeError(
+            "The 'url' needs to be a contextily.providers object," " a dict, or string"
+        )
     elif "url" not in source:
         raise ValueError("The 'url' dict should at least contain a 'url' key")
     else:
@@ -410,8 +428,7 @@ def _retryer(tile_url, wait, max_retries):
                 max_retries -= 1
                 request = _retryer(tile_url, wait, max_retries)
             else:
-                raise requests.HTTPError(
-                    "Connection reset by peer too many times.")
+                raise requests.HTTPError("Connection reset by peer too many times.")
     return request
 
 
@@ -473,8 +490,7 @@ def bb2wdw(bb, rtr):
     yi = np.linspace(rbb.bottom, rbb.top, rtr.shape[0])
 
     window = (
-        (rtr.shape[0] - yi.searchsorted(bb[3]),
-         rtr.shape[0] - yi.searchsorted(bb[1])),
+        (rtr.shape[0] - yi.searchsorted(bb[3]), rtr.shape[0] - yi.searchsorted(bb[1])),
         (xi.searchsorted(bb[0]), xi.searchsorted(bb[2])),
     )
     return window
@@ -504,8 +520,7 @@ def _sm2ll(x, y):
     shift = np.pi * rMajor
     lon = x / shift * 180.0
     lat = y / shift * 180.0
-    lat = 180.0 / np.pi * \
-        (2.0 * np.arctan(np.exp(lat * np.pi / 180.0)) - np.pi / 2.0)
+    lat = 180.0 / np.pi * (2.0 * np.arctan(np.exp(lat * np.pi / 180.0)) - np.pi / 2.0)
     return lon, lat
 
 
@@ -634,7 +649,7 @@ def _merge_tiles(tiles, arrays):
 
     for ind, arr in zip(indices, arrays):
         x, y = ind
-        img[y * h: (y + 1) * h, x * w: (x + 1) * w, :] = arr
+        img[y * h : (y + 1) * h, x * w : (x + 1) * w, :] = arr
 
     bounds = np.array([mt.bounds(t) for t in tiles])
     west, south, east, north = (

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -22,6 +22,7 @@ from rasterio.vrt import WarpedVRT
 from rasterio.enums import Resampling
 from . import tile_providers as sources
 from . import providers
+from ._providers import TileProvider
 
 __all__ = ["bounds2raster", "bounds2img",
            "warp_tiles", "warp_img_transform", "howmany"]
@@ -226,11 +227,11 @@ def _url_from_string(url):
 def _construct_tile_url(url, x, y, z):
     if url is None:
         url = providers.Stamen.Terrain
-
     if isinstance(url, str):
         url = _url_from_string(url)
-    elif not isinstance(url, dict):
-        raise TypeError("The 'url' needs to be a dict or string")
+    elif not isinstance(url, (dict, TileProvider)):
+        raise TypeError("The 'url' needs to be a contextily.providers object,"
+                        " a dict, or string")
     elif "url" not in url:
         raise ValueError("The 'url' dict should at least contain a 'url' key")
     else:

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -252,7 +252,7 @@ def _process_source(source):
         provider = _url_from_string(source)
     elif not isinstance(source, (dict, TileProvider)):
         raise TypeError(
-            "The 'url' needs to be a contextily.providers object," " a dict, or string"
+            "The 'url' needs to be a contextily.providers object, a dict, or string"
         )
     elif "url" not in source:
         raise ValueError("The 'url' dict should at least contain a 'url' key")

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -187,7 +187,7 @@ def bounds2img(w, s, e, n, zoom="auto", source=None,
                       ' argument. Do not supply a "url" argument. It will be ignored.',
                       FutureWarning, stacklevel=2)
     # get provider dict given the url
-    provider = _process_url(url)
+    provider = _process_source(source)
     # calculate and validate zoom level
     auto_zoom = zoom == "auto"
     if auto_zoom:
@@ -228,18 +228,18 @@ def _url_from_string(url):
     return {"url": url}
 
 
-def _process_url(url):
-    if url is None:
-        url = providers.Stamen.Terrain
-    if isinstance(url, str):
-        url = _url_from_string(url)
-    elif not isinstance(url, (dict, TileProvider)):
+def _process_source(source):
+    if source is None:
+        provider = providers.Stamen.Terrain
+    elif isinstance(source, str):
+        provider = _url_from_string(source)
+    elif not isinstance(source, (dict, TileProvider)):
         raise TypeError("The 'url' needs to be a contextily.providers object,"
                         " a dict, or string")
-    elif "url" not in url:
+    elif "url" not in source:
         raise ValueError("The 'url' dict should at least contain a 'url' key")
     else:
-        provider = url
+        provider = source
     return provider
 
 

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -183,12 +183,12 @@ def bounds2img(w, s, e, n, zoom="auto", source=None,
         zoom = _calculate_zoom(w, s, e, n)
     if url is not None and source is None:
         warnings.warn('The "url" option is deprecated. Please use the "source"'
-                      ' argument instead.', DeprecationWarning)
+                      ' argument instead.', FutureWarning)
         source = url
     elif url is not None and source is not None:
         warnings.warn('The "url" argument is deprecated. Please use the "source"'
                       ' argument. Do not supply a "url" argument. It will be ignored.',
-                      DeprecationWarning)
+                      FutureWarning)
     tiles = []
     arrays = []
     for t in mt.tiles(w, s, e, n, [zoom]):
@@ -214,7 +214,7 @@ def _url_from_string(url):
         warnings.warn(
             "The url format using 'tileX', 'tileY', 'tileZ' as placeholders "
             "is deprecated. Please use '{x}', '{y}', '{z}' instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
         url = (
             url.replace("tileX", "{x}").replace(

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -40,8 +40,8 @@ def _clear_cache():
 atexit.register(_clear_cache)
 
 
-def bounds2raster(w, s, e, n, path, zoom="auto", url=None, source=None,
-                  ll=False, wait=0, max_retries=2):
+def bounds2raster(w, s, e, n, path, zoom="auto", source=None,
+                  ll=False, wait=0, max_retries=2, url=None):
     """
     Take bounding box and zoom, and write tiles into a raster file in
     the Spherical Mercator CRS (EPSG:3857)
@@ -62,12 +62,7 @@ def bounds2raster(w, s, e, n, path, zoom="auto", url=None, source=None,
               Level of detail
     path    : str
               Path to raster file to be written
-    url     : str [DEPRECATED]
-              [Optional. Default:
-              'http://tile.stamen.com/terrain/tileZ/tileX/tileY.png'] URL for
-              tile provider. The placeholders for the XYZ need to be `tileX`,
-              `tileY`, `tileZ`, respectively. See `cx.sources`.
-    source  : contextily.tile or str
+   source  : contextily.tile or str
               [Optional. Default: 'http://tile.stamen.com/terrain/tileZ/tileX/tileY.png']
               URL for tile provider. The placeholders for the XYZ need to be
               `tileX`, `tileY`, `tileZ`, respectively. IMPORTANT: tiles are
@@ -83,6 +78,11 @@ def bounds2raster(w, s, e, n, path, zoom="auto", url=None, source=None,
                  [Optional. Default: 2]
                  total number of rejected requests allowed before contextily
                  will stop trying to fetch more tiles from a rate-limited API.
+    url     : str [DEPRECATED]
+              [Optional. Default:
+              'http://tile.stamen.com/terrain/tileZ/tileX/tileY.png'] URL for
+              tile provider. The placeholders for the XYZ need to be `tileX`,
+              `tileY`, `tileZ`, respectively. See `cx.sources`.
 
     Returns
     -------
@@ -127,7 +127,7 @@ def bounds2raster(w, s, e, n, path, zoom="auto", url=None, source=None,
 
 
 def bounds2img(w, s, e, n, zoom="auto", source=None,
-               url=None, ll=False, wait=0, max_retries=2):
+               ll=False, wait=0, max_retries=2, url=None):
     """
     Take bounding box and zoom and return an image with all the tiles
     that compose the map and its Spherical Mercator extent.
@@ -146,11 +146,6 @@ def bounds2img(w, s, e, n, zoom="auto", source=None,
               North edge
     zoom    : int
               Level of detail
-    url     : str [DEPRECATED]
-              [Optional. Default: 'http://tile.stamen.com/terrain/tileZ/tileX/tileY.png']
-              URL for tile provider. The placeholders for the XYZ need to be
-              `tileX`, `tileY`, `tileZ`, respectively. IMPORTANT: tiles are
-              assumed to be in the Spherical Mercator projection (EPSG:3857).
     source  : contextily.tile or str
               [Optional. Default: 'http://tile.stamen.com/terrain/tileZ/tileX/tileY.png']
               URL for tile provider. The placeholders for the XYZ need to be
@@ -167,6 +162,11 @@ def bounds2img(w, s, e, n, zoom="auto", source=None,
                  [Optional. Default: 2]
                  total number of rejected requests allowed before contextily
                  will stop trying to fetch more tiles from a rate-limited API.
+    url     : str [DEPRECATED]
+              [Optional. Default: 'http://tile.stamen.com/terrain/tileZ/tileX/tileY.png']
+              URL for tile provider. The placeholders for the XYZ need to be
+              `tileX`, `tileY`, `tileZ`, respectively. IMPORTANT: tiles are
+              assumed to be in the Spherical Mercator projection (EPSG:3857).
 
     Returns
     -------

--- a/contextily/tile.py
+++ b/contextily/tile.py
@@ -183,12 +183,12 @@ def bounds2img(w, s, e, n, zoom="auto", source=None,
         zoom = _calculate_zoom(w, s, e, n)
     if url is not None and source is None:
         warnings.warn('The "url" option is deprecated. Please use the "source"'
-                      ' argument instead.', FutureWarning)
+                      ' argument instead.', FutureWarning, stacklevel=2)
         source = url
     elif url is not None and source is not None:
         warnings.warn('The "url" argument is deprecated. Please use the "source"'
                       ' argument. Do not supply a "url" argument. It will be ignored.',
-                      FutureWarning)
+                      FutureWarning, stacklevel=2)
     tiles = []
     arrays = []
     for t in mt.tiles(w, s, e, n, [zoom]):

--- a/contextily/tile_providers.py
+++ b/contextily/tile_providers.py
@@ -1,22 +1,37 @@
 """Common tile provider URLs."""
+import warnings
 
 ### Tile provider sources ###
 
-ST_TONER = "http://tile.stamen.com/toner/{z}/{x}/{y}.png"
-ST_TONER_HYBRID = "http://tile.stamen.com/toner-hybrid/{z}/{x}/{y}.png"
-ST_TONER_LABELS = "http://tile.stamen.com/toner-labels/{z}/{x}/{y}.png"
-ST_TONER_LINES = "http://tile.stamen.com/toner-lines/{z}/{x}/{y}.png"
-ST_TONER_BACKGROUND = "http://tile.stamen.com/toner-background/{z}/{x}/{y}.png"
-ST_TONER_LITE = "http://tile.stamen.com/toner-lite/{z}/{x}/{y}.png"
+_ST_TONER = "http://tile.stamen.com/toner/{z}/{x}/{y}.png"
+_ST_TONER_HYBRID = "http://tile.stamen.com/toner-hybrid/{z}/{x}/{y}.png"
+_ST_TONER_LABELS = "http://tile.stamen.com/toner-labels/{z}/{x}/{y}.png"
+_ST_TONER_LINES = "http://tile.stamen.com/toner-lines/{z}/{x}/{y}.png"
+_ST_TONER_BACKGROUND = "http://tile.stamen.com/toner-background/{z}/{x}/{y}.png"
+_ST_TONER_LITE = "http://tile.stamen.com/toner-lite/{z}/{x}/{y}.png"
 
-ST_TERRAIN = "http://tile.stamen.com/terrain/{z}/{x}/{y}.png"
-ST_TERRAIN_LABELS = "http://tile.stamen.com/terrain-labels/{z}/{x}/{y}.png"
-ST_TERRAIN_LINES = "http://tile.stamen.com/terrain-lines/{z}/{x}/{y}.png"
-ST_TERRAIN_BACKGROUND = "http://tile.stamen.com/terrain-background/{z}/{x}/{y}.png"
+_ST_TERRAIN = "http://tile.stamen.com/terrain/{z}/{x}/{y}.png"
+_ST_TERRAIN_LABELS = "http://tile.stamen.com/terrain-labels/{z}/{x}/{y}.png"
+_ST_TERRAIN_LINES = "http://tile.stamen.com/terrain-lines/{z}/{x}/{y}.png"
+_ST_TERRAIN_BACKGROUND = "http://tile.stamen.com/terrain-background/{z}/{x}/{y}.png"
 
-ST_WATERCOLOR = "http://tile.stamen.com/watercolor/{z}/{x}/{y}.png"
+_T_WATERCOLOR = "http://tile.stamen.com/watercolor/{z}/{x}/{y}.png"
 
 # OpenStreetMap as an alternative
-OSM_A = "http://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
-OSM_B = "http://b.tile.openstreetmap.org/{z}/{x}/{y}.png"
-OSM_C = "http://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
+_OSM_A = "http://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
+_OSM_B = "http://b.tile.openstreetmap.org/{z}/{x}/{y}.png"
+_OSM_C = "http://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
+
+deprecated_names = {k.lstrip('_') for k, v in locals().items()
+                    if (False if not isinstance(v, str)
+                        else (v.startswith('http')))
+                    }
+
+
+def __getattr__(name):
+    if name in deprecated_names:
+        warnings.warn('The "contextily.tile_providers" module will be deprecated in'
+                      'contextily v1.1. Please use "contextily.providers" instead.',
+                      DeprecationWarning)
+        return globals()[f'_{name}']
+    raise AttributeError(f'module {__name__} has no attribute {name}')

--- a/contextily/tile_providers.py
+++ b/contextily/tile_providers.py
@@ -32,6 +32,6 @@ def __getattr__(name):
     if name in deprecated_names:
         warnings.warn('The "contextily.tile_providers" module will be deprecated in'
                       'contextily v1.1. Please use "contextily.providers" instead.',
-                      DeprecationWarning)
+                      FutureWarning)
         return globals()[f'_{name}']
     raise AttributeError(f'module {__name__} has no attribute {name}')

--- a/contextily/tile_providers.py
+++ b/contextily/tile_providers.py
@@ -32,6 +32,6 @@ def __getattr__(name):
     if name in deprecated_names:
         warnings.warn('The "contextily.tile_providers" module is deprecated and will be removed in '
                       'contextily v1.1. Please use "contextily.providers" instead.',
-                      FutureWarning)
+                      FutureWarning, stacklevel=2)
         return globals()[f'_{name}']
     raise AttributeError(f'module {__name__} has no attribute {name}')

--- a/contextily/tile_providers.py
+++ b/contextily/tile_providers.py
@@ -1,5 +1,6 @@
 """Common tile provider URLs."""
 import warnings
+import sys
 
 ### Tile provider sources ###
 
@@ -35,3 +36,7 @@ def __getattr__(name):
                       FutureWarning, stacklevel=2)
         return globals()[f'_{name}']
     raise AttributeError(f'module {__name__} has no attribute {name}')
+
+
+if (sys.version_info.major == 3 and sys.version_info.minor < 7):
+    globals().update({k: globals().get('_'+k) for k in deprecated_sources})

--- a/contextily/tile_providers.py
+++ b/contextily/tile_providers.py
@@ -30,7 +30,7 @@ deprecated_names = {k.lstrip('_') for k, v in locals().items()
 
 def __getattr__(name):
     if name in deprecated_names:
-        warnings.warn('The "contextily.tile_providers" module will be deprecated in'
+        warnings.warn('The "contextily.tile_providers" module is deprecated and will be removed in '
                       'contextily v1.1. Please use "contextily.providers" instead.',
                       FutureWarning)
         return globals()[f'_{name}']

--- a/contextily/tile_providers.py
+++ b/contextily/tile_providers.py
@@ -22,14 +22,14 @@ _OSM_A = "http://a.tile.openstreetmap.org/{z}/{x}/{y}.png"
 _OSM_B = "http://b.tile.openstreetmap.org/{z}/{x}/{y}.png"
 _OSM_C = "http://c.tile.openstreetmap.org/{z}/{x}/{y}.png"
 
-deprecated_names = {k.lstrip('_') for k, v in locals().items()
-                    if (False if not isinstance(v, str)
-                        else (v.startswith('http')))
-                    }
+deprecated_sources = {k.lstrip('_') for k, v in locals().items()
+                      if (False if not isinstance(v, str)
+                          else (v.startswith('http')))
+                      }
 
 
 def __getattr__(name):
-    if name in deprecated_names:
+    if name in deprecated_sources:
         warnings.warn('The "contextily.tile_providers" module is deprecated and will be removed in '
                       'contextily v1.1. Please use "contextily.providers" instead.',
                       FutureWarning, stacklevel=2)

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -16,7 +16,7 @@ def test_sources():
     sources = tilers.deprecated_sources
     for src in sources:
         img, ext = ctx.bounds2img(
-            w, s, e, n, 4, url=getattr(tilers, '_'+src), ll=True)
+            w, s, e, n, 4, url=getattr(tilers, src), ll=True)
 
 
 def test_deprecated_url_format():

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -16,7 +16,7 @@ def test_sources():
     sources = tilers.deprecated_sources
     for src in sources:
         img, ext = ctx.bounds2img(
-            w, s, e, n, 4, url=getattr(tilers, src), ll=True)
+            w, s, e, n, 4, url=getattr(tilers, '_'+src), ll=True)
 
 
 def test_deprecated_url_format():

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -13,9 +13,10 @@ def test_sources():
         -93.50721740722656,
         36.49387741088867,
     )
-    sources = [i for i in dir(tilers) if i[0] != "_"]
+    sources = tilers.deprecated_sources
     for src in sources:
-        img, ext = ctx.bounds2img(w, s, e, n, 4, url=getattr(tilers, src), ll=True)
+        img, ext = ctx.bounds2img(
+            w, s, e, n, 4, url=getattr(tilers, src), ll=True)
 
 
 def test_deprecated_url_format():


### PR DESCRIPTION
This addresses points discussed in #90 by adding:
1. a new argument `source` that supplants `url`. 
2. a deprecation warning whenever `url` is provided to either `bounds2img` or `bounds2raster`
3. a deprecation warning whenever one of the `contextily.tile_providers` strings is accessed

For some reason on my local computer (python 3.7.6) I do not see the warning text, despite verifying that the conditional in `tile_providers.py` is evaluated & the replacement string is returned correctly. Is this just my install? or do others not see the warning text? 

Closes #90