### PR TITLE
ENH: support reading window from local files (#86)

### DIFF
--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -6,7 +6,6 @@ from . import providers
 from .tile import _calculate_zoom, bounds2img, _sm2ll, warp_tiles, _warper
 from rasterio.enums import Resampling
 from rasterio.warp import transform_bounds
-from shapely.geometry import Polygon
 from matplotlib import patheffects
 from matplotlib.pyplot import draw
 
@@ -162,8 +161,6 @@ def add_basemap(
     # Plotting
     if image.shape[2] == 1:
         image = image[:, :, 0]
-        print(image.shape)
-        print(extent)
     img = ax.imshow(
         image, extent=extent, interpolation=interpolation, **extra_imshow_args
     )

--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -24,7 +24,8 @@ def add_basemap(
     reset_extent=True,
     crs=None,
     resampling=Resampling.bilinear,
-    **extra_imshow_args):
+    **extra_imshow_args
+):
     """
     Add a (web/local) basemap to `ax`
     ...
@@ -124,27 +125,33 @@ def add_basemap(
     # If local source
     else:
         import rasterio as rio
+
         # Read file
         with rio.open(url) as raster:
             if reset_extent:
                 from rasterio.mask import mask as riomask
+
                 # Read window
                 if crs:
-                    left, bottom, right, top = rio.warp.transform_bounds(crs,
-                                                                         raster.crs,
-                                                                         xmin,
-                                                                         ymin,
-                                                                         xmax,
-                                                                         ymax
-                                                                         )
+                    left, bottom, right, top = rio.warp.transform_bounds(
+                        crs, raster.crs, xmin, ymin, xmax, ymax
+                    )
                 else:
                     left, bottom, right, top = xmin, ymin, xmax, ymax
-                window = [{'type': 'Polygon',
-                          'coordinates': (((left, bottom),
-                                           (right, bottom),
-                                           (right, top),
-                                           (left, top),
-                                           (left, bottom)),)}]
+                window = [
+                    {
+                        "type": "Polygon",
+                        "coordinates": (
+                            (
+                                (left, bottom),
+                                (right, bottom),
+                                (right, top),
+                                (left, top),
+                                (left, bottom),
+                            ),
+                        ),
+                    }
+                ]
                 image, img_transform = riomask(raster, window, crop=True)
             else:
                 # Read full
@@ -168,10 +175,12 @@ def add_basemap(
     if reset_extent:
         ax.axis((xmin, xmax, ymin, ymax))
     else:
-        max_bounds = (min(xmin, extent[0]),
-                      max(xmax, extent[1]),
-                      min(ymin, extent[2]),
-                      max(ymax, extent[3]))
+        max_bounds = (
+            min(xmin, extent[0]),
+            max(xmax, extent[1]),
+            min(ymin, extent[2]),
+            max(ymax, extent[3]),
+        )
         ax.axis(max_bounds)
 
     # Add attribution text

--- a/contextily/plotting.py
+++ b/contextily/plotting.py
@@ -160,6 +160,10 @@ def add_basemap(
             bb = raster.bounds
             extent = bb.left, bb.right, bb.bottom, bb.top
     # Plotting
+    if image.shape[2] == 1:
+        image = image[:, :, 0]
+        print(image.shape)
+        print(extent)
     img = ax.imshow(
         image, extent=extent, interpolation=interpolation, **extra_imshow_args
     )

--- a/tests/test_ctx.py
+++ b/tests/test_ctx.py
@@ -253,11 +253,36 @@ def test_add_basemap():
     assert_array_almost_equal(ax.images[0].get_array().mean(), 177.20665995279947)
 
     # Test local source
+    ## Windowed read
+    subset = (
+        -11730803.981631357,
+        -11711668.223149346,
+        4862910.488797557,
+        4882046.247279563,
+    )
+
+    f, ax = matplotlib.pyplot.subplots(1)
+    ax.set_xlim(subset[0], subset[1])
+    ax.set_ylim(subset[2], subset[3])
+    loc = ctx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
+    ctx.add_basemap(ax, url="./test2.tif", reset_extent=True)
+
+    raster_extent = (
+        -11740803.981631357,
+        -11701668.223149346,
+        4852910.488797556,
+        4892046.247279563
+    )
+    assert_array_almost_equal(raster_extent, ax.images[0].get_extent())
+    assert ax.images[0].get_array().sum() == 8440966
+    assert ax.images[0].get_array().shape == (126, 126, 3)
+    assert_array_almost_equal(ax.images[0].get_array().mean(), 177.22696733014195)
+    ## Full read
     f, ax = matplotlib.pyplot.subplots(1)
     ax.set_xlim(x1, x2)
     ax.set_ylim(y1, y2)
     loc = ctx.Place(SEARCH, path="./test2.tif", zoom_adjust=ADJUST)
-    ctx.add_basemap(ax, url="./test2.tif")
+    ctx.add_basemap(ax, url="./test2.tif", reset_extent=False)
 
     raster_extent = (
         -11740803.981631357,
@@ -307,9 +332,9 @@ def test_add_basemap():
     ctx.add_basemap(ax, url="./test2.tif", crs={"init": "epsg:4326"}, attribution=None)
     assert ax.get_xlim() == (x1, x2)
     assert ax.get_ylim() == (y1, y2)
-    assert ax.images[0].get_array().sum() == 724238693
-    assert ax.images[0].get_array().shape == (1135, 1183, 3)
-    assert_array_almost_equal(ax.images[0].get_array().mean(), 179.79593258881636)
+    assert ax.images[0].get_array().sum() == 464751694
+    assert ax.images[0].get_array().shape == (980, 862, 3)
+    assert_array_almost_equal(ax.images[0].get_array().mean(), 183.38608756727749)
 
 
 def test_basemap_attribution():


### PR DESCRIPTION
This adds support for memory-efficient, window-based reading of local files when `reset_extent=True`, addressing #86, and also fixes #100 by squeezing 1-band rasters to a two-dimensional image before plotting.