### PR TITLE
Use customized version of the pydata-sphinx-theme

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,50 @@
+/* Override some aspects of the pydata-sphinx-theme */
+
+body {
+  padding-top: 0px;
+}
+
+h1,
+h2 {
+  color: #333;
+}
+
+@media (min-width: 768px) {
+  @supports (position: -webkit-sticky) or (position: sticky) {
+    .bd-sidebar {
+      top: 40px;
+    }
+  }
+}
+
+/* no pink for code */
+code {
+  color: #3b444b;
+}
+
+/* Default link color for active + larger font size for sidebar*/
+.bd-sidebar .nav > li > a {
+  font-size: 1em;
+}
+
+.bd-sidebar .nav>li>a:hover,
+.bd-sidebar .nav > .active:hover > a,
+.bd-sidebar .nav > .active > a {
+  color: #005b81;
+}
+.toc-entry > .nav-link.active {
+  color: #005b81;
+  border-left:2px solid #005b81;
+}
+
+
+/* New element: brand text instead of logo */
+
+/* .navbar-brand-text {
+  padding: 1rem;
+} */
+
+a.navbar-brand-text {
+  color: #333;
+  font-size: xx-large;
+}

--- a/docs/_templates/docs-sidebar.html
+++ b/docs/_templates/docs-sidebar.html
@@ -1,0 +1,33 @@
+
+{% if logo %}
+<a class="navbar-brand" href="{{ pathto(master_doc) }}">
+  <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo">
+</a>
+{% else %}
+<a class="navbar-brand-text" href="{{ pathto(master_doc) }}">
+CONTEXTILY!
+</a>
+{% endif %}
+
+
+<form class="bd-search d-flex align-items-center" action="{{ pathto('search') }}" method="get">
+    <i class="icon fas fa-search"></i>
+    <input type="search" class="form-control" name="q" id="search-input" placeholder="{{ theme_search_bar_text }}" aria-label="{{ theme_search_bar_text }}" autocomplete="off" >
+  </form>
+  
+  <nav class="bd-links" id="bd-docs-nav" aria-label="Main navigation">
+  
+    <div class="bd-toc-item active">
+    {% set nav = get_nav_object(maxdepth=3, collapse=True) %}
+  
+
+
+    <ul class="nav bd-sidenav">
+        {% for nav_item in nav %}
+        <li class="nav-item {% if nav_item.active%}active{% endif %}">
+            <a class="nav-link" href="{{ nav_item.url }}">{{ nav_item.title }}</a>
+        </li>
+        {% endfor %}
+    </ul>
+  
+  </nav>

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,9 @@
+{% extends "pydata_sphinx_theme/layout.html" %}
+
+<!-- Docs TOC is "d-none d-xl-block col-xl-2" -->
+
+{# Silence the navbar #}
+{% block docs_navbar %}
+{% endblock %}
+
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,6 +42,9 @@ extensions = [
     "nbsphinx"
 ]
 
+# nbsphinx do not use requirejs (breaks bootstrap)
+nbsphinx_requirejs_path = ""
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
@@ -56,12 +59,16 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'pydata_sphinx_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+html_css_files = [
+    'css/custom.css',
+]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This is what I currently need for getting http://jorisvandenbossche.github.io/example-pandas-docs/contextily/index.html

Some of the custom css should not be needed if we can improve the ability to override eg the highlight color in the upstream theme. But it's good to experiment with this to see how we can improve the extendibility of the theme.